### PR TITLE
Update the manifest.ini file of zh_CN to fix the bug that the goldWave plugin cannot be installed in the Chinese environment.

### DIFF
--- a/addon/locale/zh_CN/manifest.ini
+++ b/addon/locale/zh_CN/manifest.ini
@@ -1,0 +1,9 @@
+name = goldwave
+summary = "GoldWave"
+description = """一个提高音频编辑器 Goldwave 的可访问性和提供小贴士的插件。"""
+author = "Joseph Lee <joseph.lee22590@gmail.com>, David Parduhn <xkill85@gmx.net>, Mesar Hameed <mhameed@src.gnome.org>"
+url = https://addons.nvda-project.org
+version = 18.12
+docFileName = readme.html
+minimumNVDAVersion = 2017.3
+lastTestedNVDAVersion = 2019.1


### PR DESCRIPTION
Hello josephsl This PR mainly updates the old version of the manifest.ini file, replaces the old version of the manifest.ini configuration with the new version of the manifest.ini file, and the new version of manifest.ini also solves the bug that the Chinese environment cannot install the goldWave plugin. Is the difference between the old version configuration and the new version configuration
New configuration: name = goldwave summary = "GoldWave" description = """ A plugin that improves the accessibility of the audio editor Goldwave and provides tips.""" author = "Joseph Lee , David Parduhn , Mesar Hameed " url = https://addons.nvda-project.org version = 18.12 docFileName = readme.html minimumNVDAVersion = 2017.3 lastTestedNVDAVersion = 2019.1
Version configuration:
 summary = "GoldWave
Translator:
 vgjh2005@gmail.com
Dragon" description = """ An add-on to improve the audio editor Goldwave's accessibility and tips."""
thank